### PR TITLE
feat: add control to constrain dragging to viewport

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ import { useDraggable } from './lib';
 
 function App() {
   const { targetRef, handleRef, getTargetProps } = useDraggable({
-    controlStyle: true
+    controlStyle: true,
+    viewport: true
   });
   return (
     <div

--- a/src/lib/Draggable.jsx
+++ b/src/lib/Draggable.jsx
@@ -12,6 +12,27 @@ Draggable.propTypes = {
   viewport: PropTypes.bool
 };
 
+const getViewportDimensions = () => {
+  // don't assume window in case SSR
+  if (!window) {
+    return {
+      width: document.documentElement.clientWidth,
+      height: document.documentElement.clientHeight
+    };
+  }
+  if (window.screen) {
+    return {
+      width: window.screen.availWidth,
+      height: window.screen.availHeight
+    };
+  }
+
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight
+  };
+};
+
 export function useDraggable({ controlStyle, viewport } = {}) {
   const targetRef = useRef(null);
   const handleRef = useRef(null);
@@ -34,17 +55,18 @@ export function useDraggable({ controlStyle, viewport } = {}) {
     function startDragging(event) {
       setDragging(true);
       if (viewport) {
+        const viewportDimensions = getViewportDimensions();
         const targetRectangle = targetRef.current.getBoundingClientRect();
         viewportLimits.current = {
           left: prev.x - targetRectangle.left,
           top: prev.y - targetRectangle.top,
           right:
-            document.documentElement.clientWidth -
+            viewportDimensions.width -
             targetRectangle.width -
             targetRectangle.left +
             prev.x,
           bottom:
-            document.documentElement.clientHeight -
+            viewportDimensions.height -
             targetRectangle.height -
             targetRectangle.top +
             prev.y

--- a/src/lib/Draggable.jsx
+++ b/src/lib/Draggable.jsx
@@ -8,10 +8,11 @@ export function Draggable({ children, ...rest }) {
 
 Draggable.propTypes = {
   children: PropTypes.func.isRequired,
-  controlStyle: PropTypes.bool
+  controlStyle: PropTypes.bool,
+  viewport: PropTypes.bool
 };
 
-export function useDraggable({ controlStyle } = {}) {
+export function useDraggable({ controlStyle, viewport } = {}) {
   const targetRef = useRef(null);
   const handleRef = useRef(null);
   const [dragging, setDragging] = useState(null);
@@ -82,14 +83,21 @@ export function useDraggable({ controlStyle } = {}) {
         (event.changedTouches && event.changedTouches[0]) ||
         (event.touches && event.touches[0]) ||
         event;
-      const { clientX, clientY } = source;
+      let { clientX, clientY } = source;
+      
+      if (viewport) {
+        clientX = Math.max(0, Math.min(clientX, document.documentElement.clientWidth));
+        clientY = Math.max(0, Math.min(clientY, document.documentElement.clientHeight));
+      }
       const calculatedX = clientX - initial.current.x;
       const calculatedY = clientY - initial.current.y;
+
       const newDelta = { x: calculatedX + prev.x, y: calculatedY + prev.y };
+      console.log(newDelta);
       setDelta(newDelta);
       return newDelta;
     }
-  }, [dragging, prev, controlStyle]);
+  }, [dragging, prev, controlStyle, viewport]);
 
   useEffect(() => {
     if (controlStyle) {


### PR DESCRIPTION
Adds an option to constrict dragging within the viewport.

This constricts on the mouse/touch client position, but it'd be possible to do so on the dragging element if we had access to the width/height.

Fixes: https://github.com/idanen/react-draggable/issues/1